### PR TITLE
Introduce block-facing

### DIFF
--- a/src/lambdaisland/witchcraft/cursor.clj
+++ b/src/lambdaisland/witchcraft/cursor.clj
@@ -37,8 +37,7 @@
   ```
   "
   (:refer-clojure :exclude [bean])
-  (:require [clojure.set :as set]
-            [lambdaisland.witchcraft :as wc]
+  (:require [lambdaisland.witchcraft :as wc]
             [lambdaisland.witchcraft.safe-bean :refer [bean bean->]]))
 
 (def default-material

--- a/src/lambdaisland/witchcraft/cursor.clj
+++ b/src/lambdaisland/witchcraft/cursor.clj
@@ -37,7 +37,8 @@
   ```
   "
   (:refer-clojure :exclude [bean])
-  (:require [lambdaisland.witchcraft :as wc]
+  (:require [clojure.set :as set]
+            [lambdaisland.witchcraft :as wc]
             [lambdaisland.witchcraft.safe-bean :refer [bean bean->]]))
 
 (def default-material
@@ -172,7 +173,7 @@
   If the material is a two-element vector (either explicitly or via the palette)
   then this is taken as [material material-data], and overrides the
   material-data in the cursor."
-  [{:keys [x y z material block-data
+  [{:keys [x y z material block-data block-facing
            data palette dir face-direction? rotate-block]}]
   (let [m (get palette material material)
         [m md] (if (vector? m) m [m data])
@@ -182,6 +183,8 @@
          :y y
          :z z
          :material m}
+      block-facing
+      (assoc :direction block-facing)
       face-direction?
       (assoc :direction (rotate-dir dir rotate-block))
       data
@@ -395,6 +398,13 @@
   [cursor f & args]
   (assoc cursor :blocks (:blocks (apply f cursor args))))
 
+(defn block-facing
+  "Make the cursor produce blocks with the specified direction."
+  [cursor dir]
+  (-> cursor
+      (assoc :block-facing dir)
+      (assoc :face-direction? false)))
+
 (defn extrude
   "Take the current block list and extrude it in a given direction, by default up."
   ([cursor n]
@@ -412,7 +422,9 @@
                (merge c b)
                i
                (fn [c]
-                 (step c dir))))))
+                 (-> c
+                     (block-facing (:direction b))
+                     (step dir)))))))
          c
          (range 1 (inc n))))
       cursor


### PR DESCRIPTION
To make the cursor draw blocks in a specified direction.

I found this useful when e.g. when making a roof outline  / \ using stairs and extruding the outline.
Tried using `block-data` as well but for some blocks `facing` is unsupported and throws. Also tried just having `face-direction?` set to false. But that gave undirected blocks.

So I hope this is a solution that could work?

